### PR TITLE
Fix header image not rotating daily

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,17 +8,12 @@ import headerImage4 from '@public/images/michael4.jpg';
 
 const headerImages = [headerImage1, headerImage2, headerImage3, headerImage4];
 
-const getImageOfTheDay = () => {
-  const today = new Date();
-  const dayOfYear = Math.floor(
-    (today.getTime() - new Date(today.getFullYear(), 0, 0).getTime()) /
-      (1000 * 60 * 60 * 24)
-  );
-  return headerImages[dayOfYear % headerImages.length];
-};
+interface HeaderProps {
+  dayOfYear: number;
+}
 
-const Header = () => {
-  const headerImage = getImageOfTheDay();
+const Header = ({ dayOfYear }: HeaderProps) => {
+  const headerImage = headerImages[dayOfYear % headerImages.length];
 
   return (
     <div className="flex flex-col items-center">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,12 +2,26 @@ import Container from '@components/elements/Container';
 import About from '@components/About';
 import Header from '@components/Header';
 import { MiliColorsProvider } from '@components/MiliText';
+import { GetServerSideProps } from 'next';
 
-export default function Home() {
+interface HomeProps {
+  dayOfYear: number;
+}
+
+export const getServerSideProps: GetServerSideProps<HomeProps> = async () => {
+  const today = new Date();
+  const dayOfYear = Math.floor(
+    (today.getTime() - new Date(today.getFullYear(), 0, 0).getTime()) /
+      (1000 * 60 * 60 * 24)
+  );
+  return { props: { dayOfYear } };
+};
+
+export default function Home({ dayOfYear }: HomeProps) {
   return (
     <Container>
       <MiliColorsProvider>
-        <Header />
+        <Header dayOfYear={dayOfYear} />
         <About />
       </MiliColorsProvider>
     </Container>


### PR DESCRIPTION
## Summary
- Moved day-of-year computation from client-side component render to `getServerSideProps`, so the correct header image is determined server-side on each request
- Previously, the image was computed at build time during static generation and cached, always showing `michael1.jpg` until a tab switch triggered a client re-render

## Test plan
- [ ] Verify the home page shows the correct image for today's date on first load
- [ ] Confirm no image flash/swap on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)